### PR TITLE
feat(observability): mimir for long-term metrics in ceph rgw

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/datasource.yaml
+++ b/kubernetes/apps/observability/grafana/instance/datasource.yaml
@@ -10,7 +10,7 @@ spec:
     name: prometheus
     type: prometheus
     access: proxy
-    url: http://prometheus-operated.observability.svc.cluster.local:9090
+    url: http://mimir-query-frontend.observability.svc.cluster.local:8080/prometheus
     isDefault: true
 ---
 apiVersion: grafana.integreatly.org/v1beta1

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -96,18 +96,15 @@ spec:
         ruleSelector: {}
         enableFeatures:
           - --enable-feature=memory-snapshot-on-shutdown
-        retention: 14d
-        retentionSize: '50GB'
+        retention: 24h
+        remoteWrite:
+          - url: http://mimir-distributor.observability.svc.cluster.local:8080/api/v1/push
         resources:
           limits:
             memory: 3000Mi
         storageSpec:
-          volumeClaimTemplate:
-            spec:
-              storageClassName: ceph-block
-              resources:
-                requests:
-                  storage: 50Gi
+          emptyDir:
+            sizeLimit: 4Gi
         containers:
           - name: prometheus
             livenessProbe:

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -7,5 +7,6 @@ components:
   - ../../components/common
 resources:
   - ./kube-prometheus-stack/ks.yaml
+  - ./mimir/ks.yaml
   - ./grafana/ks.yaml
   - ./smartctl-exporter/ks.yaml

--- a/kubernetes/apps/observability/mimir/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/mimir/app/helmrelease.yaml
@@ -49,10 +49,10 @@ spec:
           storage:
             backend: s3
             s3:
-              endpoint: ${BUCKET_HOST}:${BUCKET_PORT}
-              bucket_name: ${BUCKET_NAME}
-              access_key_id: ${AWS_ACCESS_KEY_ID}
-              secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+              endpoint: "$${BUCKET_HOST}:$${BUCKET_PORT}"
+              bucket_name: "$${BUCKET_NAME}"
+              access_key_id: "$${AWS_ACCESS_KEY_ID}"
+              secret_access_key: "$${AWS_SECRET_ACCESS_KEY}"
               insecure: true
         ingester:
           ring:

--- a/kubernetes/apps/observability/mimir/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/mimir/app/helmrelease.yaml
@@ -1,0 +1,127 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mimir
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: oci://ghcr.io/grafana/helm-charts/mimir-distributed
+  ref:
+    tag: 6.0.0
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mimir
+spec:
+  interval: 1h
+  timeout: 15m
+  chartRef:
+    kind: OCIRepository
+    name: mimir
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    global:
+      extraEnvFrom:
+        - secretRef:
+            name: mimir-bucket
+        - configMapRef:
+            name: mimir-bucket
+    minio:
+      enabled: false
+    mimir:
+      structuredConfig:
+        multitenancy_enabled: false
+        common:
+          storage:
+            backend: s3
+            s3:
+              endpoint: ${BUCKET_HOST}:${BUCKET_PORT}
+              bucket_name: ${BUCKET_NAME}
+              access_key_id: ${AWS_ACCESS_KEY_ID}
+              secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+              insecure: true
+        ingester:
+          ring:
+            replication_factor: 2
+        limits:
+          compactor_blocks_retention_period: 14d
+    alertmanager:
+      enabled: false
+    ruler:
+      enabled: false
+    distributor:
+      replicas: 2
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          memory: 512Mi
+    ingester:
+      replicas: 2
+      zoneAwareReplication:
+        enabled: false
+      persistentVolume:
+        enabled: false
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          memory: 2Gi
+    querier:
+      replicas: 2
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          memory: 512Mi
+    query_frontend:
+      replicas: 1
+    query_scheduler:
+      replicas: 1
+    store_gateway:
+      replicas: 2
+      zoneAwareReplication:
+        enabled: false
+      persistentVolume:
+        enabled: false
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
+    compactor:
+      replicas: 1
+      persistentVolume:
+        enabled: false
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
+    chunks-cache:
+      enabled: true
+    index-cache:
+      enabled: true
+    metadata-cache:
+      enabled: true
+    results-cache:
+      enabled: true

--- a/kubernetes/apps/observability/mimir/app/kustomization.yaml
+++ b/kubernetes/apps/observability/mimir/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./objectbucketclaim.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/observability/mimir/app/objectbucketclaim.yaml
+++ b/kubernetes/apps/observability/mimir/app/objectbucketclaim.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: mimir-bucket
+spec:
+  bucketName: mimir-bucket
+  storageClassName: ceph-bucket

--- a/kubernetes/apps/observability/mimir/ks.yaml
+++ b/kubernetes/apps/observability/mimir/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mimir
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/observability/mimir/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
Deploy Grafana Mimir (RF=2) storing blocks in Ceph RGW via OBC; switch Prometheus to a short-retention (24h, emptyDir) rule-evaluator that remote-writes to Mimir, and point the Grafana datasource at Mimir.