### PR TITLE
fix(observability): disable kafka ingest-storage on mimir 6.0

### DIFF
--- a/kubernetes/apps/observability/mimir/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/mimir/app/helmrelease.yaml
@@ -42,6 +42,8 @@ spec:
             name: mimir-bucket
     minio:
       enabled: false
+    kafka:
+      enabled: false
     mimir:
       structuredConfig:
         multitenancy_enabled: false
@@ -57,6 +59,9 @@ spec:
         ingester:
           ring:
             replication_factor: 2
+          push_grpc_method_enabled: true
+        ingest_storage:
+          enabled: false
         limits:
           compactor_blocks_retention_period: 14d
     alertmanager:


### PR DESCRIPTION
keep latest chart 6.0 but revert to classic blocks-storage architecture (ingesters -> s3, RF=2) by disabling ingest storage and the bundled demo-only kafka that stalled the ingester statefulset.