### PR TITLE
fix(observability): disable mimir rollout-operator

### DIFF
--- a/kubernetes/apps/observability/mimir/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/mimir/app/helmrelease.yaml
@@ -44,6 +44,8 @@ spec:
       enabled: false
     kafka:
       enabled: false
+    rollout_operator:
+      enabled: false
     mimir:
       structuredConfig:
         multitenancy_enabled: false


### PR DESCRIPTION
rollout-operator webhook ships a tls cert for the wrong service name (rollout-operator vs mimir-rollout-operator) which blocks all statefulset applies. it is only needed for zone-aware rollouts, which we disabled.