### PR TITLE
fix(observability): shrink mimir cache memory for homelab

### DIFF
--- a/kubernetes/apps/observability/mimir/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/mimir/app/helmrelease.yaml
@@ -126,9 +126,13 @@ spec:
           memory: 1Gi
     chunks-cache:
       enabled: true
+      allocatedMemory: 256
     index-cache:
       enabled: true
+      allocatedMemory: 256
     metadata-cache:
       enabled: true
+      allocatedMemory: 128
     results-cache:
       enabled: true
+      allocatedMemory: 256


### PR DESCRIPTION
default chunks-cache requests 8Gi which can't schedule on the 3-node cluster, stalling the helm upgrade. cap caches at 128-256MB.