### PR TITLE
fix(observability): raise mimir per-tenant series/label limits

### DIFF
--- a/kubernetes/apps/observability/mimir/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/mimir/app/helmrelease.yaml
@@ -66,6 +66,8 @@ spec:
           enabled: false
         limits:
           compactor_blocks_retention_period: 14d
+          max_label_names_per_series: 50
+          max_global_series_per_user: 500000
     alertmanager:
       enabled: false
     ruler:


### PR DESCRIPTION
prometheus remote_write hit defaults: max-label-names-per-series (30) on kube-state-metrics *_labels series, and max-global-series-per-user (150k). raise to 50 labels and 500k series.