### PR TITLE
fix(observability): raise mimir ingestion rate limit

### DIFF
--- a/kubernetes/apps/observability/mimir/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/mimir/app/helmrelease.yaml
@@ -68,6 +68,8 @@ spec:
           compactor_blocks_retention_period: 14d
           max_label_names_per_series: 50
           max_global_series_per_user: 500000
+          ingestion_rate: 50000
+          ingestion_burst_size: 1000000
     alertmanager:
       enabled: false
     ruler:


### PR DESCRIPTION
prometheus remote_write backlog after downtime exceeds the default 10k/s tenant ingestion rate (429). raise ingestion_rate to 50k and burst to 1M to absorb catch-up bursts; steady state is ~3k/s.